### PR TITLE
Add SVG Clipping Path component

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -83,6 +83,7 @@ export default function Bar (_container) {
     bars.enter()
       .append("rect")
       .attr("class", "mark rect")
+      .attr('clip-path', 'url(#mark-clip)')
       .merge(bars)
       .attr("x", (d) => scales.xScale(d[keys.KEY]) - barW / 2)
       .attr("y", (d) => {
@@ -128,6 +129,7 @@ export default function Bar (_container) {
     stackedBars.enter()
       .append("rect")
       .attr("class", "mark")
+      .attr('clip-path', 'url(#mark-clip)')
       .merge(stackedBars)
       .attr("x", (d) => scales.xScale(d.data[keys.KEY])- barW / 2)
       .attr("y", (d) => scales.yScale(d[1]) )

--- a/src/charts/chart.js
+++ b/src/charts/chart.js
@@ -17,6 +17,7 @@ import DomainEditor from "./domain-editor"
 import BrushRangeEditor from "./brush-range-editor"
 import Label from "./label"
 import DataManager from "./data-manager"
+import ClipPath from "./clip-path"
 
 export default function Chart (_container) {
 
@@ -191,7 +192,8 @@ export default function Chart (_container) {
         binning: Binning(cache.headerGroup),
         domainEditor: DomainEditor(cache.container),
         brushRangeEditor: BrushRangeEditor(cache.headerGroup),
-        label: Label(cache.container)
+        label: Label(cache.container),
+        clipPath: ClipPath(cache.svg)
       }
 
       eventCollector = {
@@ -284,6 +286,10 @@ export default function Chart (_container) {
       .render()
 
     components.label
+      .setConfig(config)
+      .render()
+
+    components.clipPath
       .setConfig(config)
       .render()
 

--- a/src/charts/clip-path.js
+++ b/src/charts/clip-path.js
@@ -1,0 +1,57 @@
+import * as d3 from "./helpers/d3-service"
+import {override} from "./helpers/common"
+
+/**
+ * ClipPath: component that creates an SVG defs element with a rectangular clipping path
+ * @param {selection} _container d3 selection representing the svg element
+ * @returns {object} object containing methods for the component
+*/
+export default function ClipPath (_container) {
+  let config = {
+    margin: {
+      top: 60,
+      right: 30,
+      bottom: 40,
+      left: 70
+    },
+    width: 800,
+    height: 500
+  }
+
+  const cache = {
+    container: _container,
+    clipPath: null,
+    chartWidth: null,
+    chartHeight: null,
+  }
+
+  function build () {
+    cache.chartWidth = config.width - config.margin.left - config.margin.right
+    cache.chartHeight = config.height - config.margin.top - config.margin.bottom
+
+    if (!cache.clipPath) {
+      cache.clipPath = cache.container.append('defs')
+        .append('clipPath')
+        .attr('id', 'mark-clip')
+        .append('rect')
+    }
+
+    cache.clipPath
+      .attr('width', cache.chartWidth)
+      .attr('height', cache.chartHeight)
+  }
+
+  function setConfig (_config) {
+    config = override(config, _config)
+    return this
+  }
+
+  function render() {
+    build()
+  }
+
+  return {
+    setConfig,
+    render
+  }
+}

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -31,7 +31,6 @@ export default function Line (_container) {
   const cache = {
     container: _container,
     svg: null,
-    clipPath: null,
     chartHeight: null,
   }
 
@@ -52,21 +51,6 @@ export default function Line (_container) {
       cache.root = cache.container.append("g")
           .classed("mark-group", true)
     }
-
-    if (!cache.clipPath) {
-      cache.container.select(function () {
-        const svg = d3.select(this.parentNode)
-        cache.clipPath = svg
-          .insert('defs', ':first-child') // inserts the <defs> el at the top
-          .append('clipPath')
-          .attr('id', 'line-clip')
-          .append('rect')
-      })
-    }
-
-    cache.clipPath
-      .attr('width', cache.chartWidth)
-      .attr('height', cache.chartHeight)
   }
 
   function drawLines () {
@@ -94,7 +78,7 @@ export default function Line (_container) {
       .append("path")
       .merge(lines)
       .attr("class", "mark line")
-      .attr('clip-path', 'url(#line-clip)')
+      .attr('clip-path', 'url(#mark-clip)')
       .classed("y2-line", (d) => d[keys.GROUP] > 0)
       .attr("d", (d) => {
         if (d[keys.GROUP] === 0) {
@@ -132,7 +116,7 @@ export default function Line (_container) {
       .append("path")
       .merge(areas)
       .attr("class", "mark area")
-      .attr('clip-path', 'url(#line-clip)')
+      .attr('clip-path', 'url(#mark-clip)')
       .classed("y2-area", (d) => d[keys.GROUP] > 0)
       .attr("d", (d) => {
         if (d[keys.GROUP] === 0) {
@@ -160,7 +144,7 @@ export default function Line (_container) {
       .append("path")
       .merge(areas)
       .attr("class", "mark stacked-area")
-      .attr('clip-path', 'url(#line-clip)')
+      .attr('clip-path', 'url(#mark-clip)')
       .attr("d", seriesLine)
       .style("stroke", "none")
       .style("fill", (d) => scales.colorScale(d.key))


### PR DESCRIPTION
So that multiple chart types don't have to check for and instantiate the necessary `defs`,  `clipPath`, and `rect` elements for an SVG clipping path.

Assists with fixing https://github.com/mapd/mapd-immerse/issues/3929