### PR TITLE
[WIP] start of formatting module and specs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -208,7 +208,7 @@
     // "space-after-function-name": 0, // removed.
     // "space-after-keywords": 0, // removed.
     "space-before-blocks": 2, // makes things look consistent with keyword spacing.
-    "space-before-function-paren": 2, // distinguishes keyword invocation from function invocation.
+    // "space-before-function-paren": 2, // distinguishes keyword invocation from function invocation.
     // "space-before-function-parentheses": 0, // removed.
     // "space-before-keywords": 0, // removed.
     // "space-in-brackets": 0, // removed.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prod": "webpack --env.prod --watch",
     "dev": "webpack --env.dev --watch",
     "clean": "yarn cache clean && rm -rf node_modules",
-    "test": "mocha-webpack test/**/*.spec.js --require test/setup.js --webpack-config webpack.config-spec.js --watch",
+    "test": "mocha-webpack test/**/*.spec.js --require test/setup.js --webpack-env.dev --webpack-config webpack.config-spec.js --watch",
     "format": "eslint \"src/**/*.js\" --fix"
   },
   "repository": {

--- a/src/charts/helpers/auto-format.js
+++ b/src/charts/helpers/auto-format.js
@@ -1,0 +1,239 @@
+import * as d3 from "./d3-service"
+// import { all, has } from "ramda"
+
+/* eslint-disable no-magic-numbers */
+const prefixTranslation = {
+  k: Math.pow(10, 3),
+  K: Math.pow(10, 3),
+  m: Math.pow(10, 6),
+  M: Math.pow(10, 6),
+  g: Math.pow(10, 9),
+  G: Math.pow(10, 9),
+  t: Math.pow(10, 12),
+  T: Math.pow(10, 12)
+}
+// /* eslint-enable no-magic-numbers */
+// function validateFormat(format) {
+//   // valid d3-format characters
+//   const hasOnlyValidCharacters = /^[-$+,.efsrpd%(0-9kKmMgGtT]+$/.test(format)
+//   // no invalid formats with duplicated valid characters like `.2ff`
+//   const hasNonRepeatingCharacters = !/([a-zA-Z]).*?\1/.test(format)
+//   return hasOnlyValidCharacters && hasNonRepeatingCharacters
+// }
+
+// function applyNumberFormatWithSuffix(tokens, value) {
+//   if (
+//     validateFormat(tokens[0]) &&
+//     tokens.length === 2 &&
+//     has(tokens[1], prefixTranslation)
+//   ) {
+//     try {
+//       return d3v4.formatPrefix(tokens[0], prefixTranslation[tokens[1]])(value)
+//     } catch (e) {
+//       // eslint-disable-next-line no-console
+//       console.warn(e)
+//       return value
+//     }
+//   } else {
+//     return value
+//   }
+// }
+
+// function applyNumberFormat(format, value) {
+//   try {
+//     return validateFormat(format) ? d3v4.format(format)(value) : value
+//   } catch (e) {
+//     // eslint-disable-next-line no-console
+//     console.warn(e)
+//     return value
+//   }
+// }
+
+function applyNumberFormat(format, value) {
+  try {
+    return d3.format(format)(value)
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("Invalid format", format)
+    return value
+  }
+}
+
+function applyNumberFormatWithSuffix(tokens, value) {
+  if (
+    tokens.length === 2 &&
+    prefixTranslation[tokens[1]]
+  ) {
+    try {
+      return d3.formatPrefix(tokens[0], prefixTranslation[tokens[1]])(value)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn("Invalid format", tokens)
+      return value
+    }
+  } else {
+    return value
+  }
+}
+
+function formatPrefixSuffix(format, value) {
+  // format like `foo {.2f} bar`
+  const tokens = format.split(/[{}]/)
+  const d3FormatToken = tokens[1]
+  const d3FormattedValue = applyNumberFormat(d3FormatToken, value)
+  return `${tokens[0]}${d3FormattedValue}${tokens[2]}`
+}
+
+function formatForcedSuffix(format, value) {
+  // format like `.2f|k`
+  const tokens = format.split("|")
+  return applyNumberFormatWithSuffix(tokens, value)
+}
+
+// export function formatterUsingIndex(measureFormats) {
+//   const measuresWithFormat = measureFormats.map(d => d.key)
+//   if (measuresWithFormat.length) {
+//     return (value, key) => {
+//       const formatIndex = measuresWithFormat.indexOf(key)
+//       if (!key && measuresWithFormat.length === 1) {
+//         const format = measureFormats[0].format
+//         return formatNumber(format, value)
+//       } else if (formatIndex > -1 && typeof value === "number") {
+//         const format = measureFormats[formatIndex].format
+//         return formatNumber(format, value)
+//       } else {
+//         return value
+//       }
+//     }
+//   } else {
+//     return null
+//   }
+// }
+
+// export function formatterWithArray(format) {
+//   if (format) {
+//     return value => {
+//       if (format && typeof value === "number") {
+//         return formatNumber(format, value)
+//       } else if (
+//         format &&
+//         Array.isArray(value) &&
+//         all(d => typeof d === "number", value)
+//       ) {
+//         return value.map(d => formatNumber(format, d))
+//       } else {
+//         return null
+//       }
+//     }
+//   } else {
+//     return null
+//   }
+// }
+
+// export function formatterSingleValue(format) {
+//   if (format) {
+//     return value => formatNumber(format, value)
+//   } else {
+//     return null
+//   }
+// }
+
+export function formatNumber(format, value) {
+  if (/[{}]/.test(format)) {
+    return formatPrefixSuffix(format, value)
+  } else if (/\|/.test(format)) {
+    return formatForcedSuffix(format, value)
+  } else {
+    return applyNumberFormat(format, value)
+  }
+}
+
+// function applyDateFormat(format, value) {
+//   try {
+//     return format ? d3v4.timeFormat(format)(value) : value
+//   } catch (e) {
+//     // eslint-disable-next-line no-console
+//     console.warn(e)
+//     return value
+//   }
+// }
+
+// export function dateFormatterUsingIndex(dimensionFormats) {
+//   const dimensionsWithFormat = dimensionFormats.map(d => d.key)
+//   if (dimensionFormats.length) {
+//     return (value, key) => {
+//       const formatIndex = dimensionsWithFormat.indexOf(key)
+//       if (formatIndex > -1 && value instanceof Date) {
+//         const format = dimensionFormats[formatIndex].format
+//         return formatDate(format, value)
+//       } else {
+//         return null
+//       }
+//     }
+//   } else {
+//     return null
+//   }
+// }
+
+// export function dateFormatterWithArray(format) {
+//   if (format) {
+//     return value => {
+//       if (format && value instanceof Date) {
+//         return formatDate(format, value)
+//       } else if (
+//         format &&
+//         Array.isArray(value) &&
+//         all(d => d instanceof Date, value)
+//       ) {
+//         return value.map(d => formatDate(format, d))
+//       } else {
+//         return null
+//       }
+//     }
+//   } else {
+//     return null
+//   }
+// }
+
+// export function formatterSingleDateValue(format) {
+//   return () => value => (format ? formatDate(format, value) : null)
+// }
+
+export function formatDate(format, value) {
+  return applyDateFormat(format, value)
+}
+
+export function parseType(format, value) {
+  if (typeof value === "number") {
+    return formatNumber(format, value)
+  } else if (value instanceof Date) {
+    return formatDate(format, value)
+  } else {
+    return String(value)
+  }
+}
+
+export function autoFormatter(_format) {
+  console.log("autoFormatter", _format)
+  return (value, key) => {
+    console.log("to format", value, key)
+
+    // To do: format from key
+    const format = _format
+
+    if (!format) {
+      return null
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(d => parseType(format, d)).join(" - ")
+    } else {
+      return parseType(format, value)
+    }
+
+
+    // if (typeof key === "undefined") {
+    //   return formatNumber(format, value)
+    // }
+  }
+}

--- a/test/formatter.spec.js
+++ b/test/formatter.spec.js
@@ -1,0 +1,113 @@
+import {expect} from "chai"
+import {autoFormatter} from "../src/charts/helpers/auto-format"
+/* eslint-disable no-unused-expressions, no-undefined */
+
+describe("Automatic Formatter", () => {
+
+  const BASE_NUMBER = 12345.678
+  const BASE_DATE = new Date("3/21/2018")
+
+  describe("Number formatters", () => {
+
+    it("should round to a number of decimals", () => {
+      const formatted = autoFormatter(".2f")(BASE_NUMBER)
+      expect(formatted.split(".")[1]).to.equal("68")
+    })
+
+    it("should add thousand separators", () => {
+      const formatted = autoFormatter(",")(BASE_NUMBER)
+      expect(formatted).to.equal("12,345.678")
+    })
+
+    it("should round to integer", () => {
+      const formatted = autoFormatter(".0f")(BASE_NUMBER)
+      expect(formatted).to.equal("12346")
+    })
+
+    it("should round to SI format with given precision", () => {
+      const formatted = autoFormatter(".2s")(BASE_NUMBER)
+      expect(formatted).to.equal("12k")
+    })
+
+    it("should convert to percentage, multiplying by 100", () => {
+      const formatted = autoFormatter(".0%")(0.25)
+      expect(formatted).to.equal("25%")
+    })
+
+    it("should convert to percentage with given precision", () => {
+      const formatted = autoFormatter(".2p")(BASE_NUMBER)
+      expect(formatted).to.equal("1200000%")
+    })
+
+    it("should convert to currency (locale specific)", () => {
+      const formatted = autoFormatter("-$.2f")(BASE_NUMBER)
+      expect(formatted).to.equal("$12345.68")
+    })
+
+    it("should use minus sign for negative currency", () => {
+      const formatted = autoFormatter("-$.2f")(-BASE_NUMBER)
+      expect(formatted).to.equal("-$12345.68")
+    })
+
+    it("should use parenthesis for negative currency", () => {
+      const formatted = autoFormatter("($.2f")(-BASE_NUMBER)
+      expect(formatted).to.equal("($12345.68)")
+    })
+
+    it("should force an SI suffix with given precision", () => {
+      const formatted = autoFormatter(",.3s|M")(BASE_NUMBER)
+      expect(formatted).to.equal("0.012M")
+    })
+
+    it("should add prefix/suffix", () => {
+      const formatted = autoFormatter("AVG {.2f}km/h")(BASE_NUMBER)
+      expect(formatted).to.equal("AVG 12345.68km/h")
+    })
+
+    it("should return the value on invalid formatter", () => {
+      const formatted = autoFormatter("aaaaa")(BASE_NUMBER)
+      expect(formatted).to.equal(BASE_NUMBER)
+    })
+
+    it("should return null if there's no formatter", () => {
+      const formatted = autoFormatter(null)(BASE_NUMBER)
+      expect(formatted).to.be.null
+    })
+
+  })
+
+  describe("Value input", () => {
+
+    it("should handle array input", () => {
+      const formatted = autoFormatter(".2s")([1234.567, 89])
+      expect(formatted).to.equal("1.2k - 89")
+    })
+
+    it("should pass through string input", () => {
+      const formatted = autoFormatter(".2s")("foo")
+      expect(formatted).to.equal("foo")
+    })
+
+    it("should convert unsupported value types to string", () => {
+      const formatted = autoFormatter(".2s")(undefined)
+      expect(formatted).to.equal("undefined")
+
+      const formatted2 = autoFormatter(".2s")({})
+      expect(formatted2).to.equal("[object Object]")
+
+      const formatted3 = autoFormatter(".2s")(null)
+      expect(formatted3).to.equal("null")
+    })
+
+  })
+
+  describe("Date formatters", () => {
+
+    it("should handle typical date formats", () => {
+      const formatted = autoFormatter("%Y-%m-%d")(BASE_DATE)
+      expect(formatted).to.equal("AVG -12345.68km/h")
+    })
+
+  })
+
+})

--- a/webpack.config-spec.js
+++ b/webpack.config-spec.js
@@ -16,6 +16,13 @@ module.exports = {
   devtool: "inline-cheap-module-source-map",
   module: {
     rules: [
+      {
+        test: /\.js$/,
+        exclude: /(node_modules|doc|dist|dev)/,
+        use: {
+          loader: "babel-loader"
+        }
+      },
       {test: /\.scss$/, loader: "null-loader"},
       {test: /\.css$/, loader: "null-loader"}
     ]


### PR DESCRIPTION
### Description
I'm using mapd3 to refactor the formatter as a module with complete test coverage.
The tests can be run with a watcher using `npm run test`