### PR TITLE
use postcss autoprefixer in webpack dev mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,7 +93,24 @@ const config = env => {
           },
           {
             test: /\.(sass|scss)$/,
-            use: ExtractTextPlugin.extract(["css-loader", "sass-loader"])
+            use: ExtractTextPlugin.extract({
+              use: [
+                {
+                  loader: "css-loader"
+                },
+                {
+                  loader: "postcss-loader",
+                  options: {
+                    config: {
+                      path: "postcss.config.js"
+                    }
+                  }
+                },
+                {
+                  loader: "sass-loader"
+                }
+              ]
+            })
           }
         ]
       },


### PR DESCRIPTION
Make sure we use autoprefixer while developing.  

I noticed that in PRs following the last mapd3 release CSS vendor prefixes are getting removed because we are compiling the CSS via `yarn run dev` and webpack was not configured to use autoprefixer in dev mode. This PR fixes this.